### PR TITLE
Fix a missing import statement in guestbook example

### DIFF
--- a/doc/tutorials/examples/actionscript/guestbook/flex/src/org/pyamf/examples/guestbook/GuestbookExample.as
+++ b/doc/tutorials/examples/actionscript/guestbook/flex/src/org/pyamf/examples/guestbook/GuestbookExample.as
@@ -13,6 +13,7 @@ package org.pyamf.examples.guestbook
 	import mx.collections.ArrayCollection;
 	import mx.core.Application;
 	import mx.events.FlexEvent;
+	import mx.utils.ObjectProxy;
 	
 	import org.pyamf.examples.guestbook.components.SubmitBox;
 	import org.pyamf.examples.guestbook.events.SubmitEvent;


### PR DESCRIPTION
They must change what libraries get included by default with different versions
