### PR TITLE
broken-api-links.patch

### DIFF
--- a/cpyamf/__init__.py
+++ b/cpyamf/__init__.py
@@ -4,5 +4,5 @@
 """
 Python C-extensions for L{PyAMF<pyamf>}.
 
-:since: 0.4
+@since: 0.4
 """

--- a/pyamf/amf3.py
+++ b/pyamf/amf3.py
@@ -84,7 +84,7 @@ TYPE_STRING = '\x06'
 #: C{XMLDocument} instance by using an index to the implicit object reference
 #: table.
 #: @see: U{OSFlash documentation (external)
-#: <http://osflash.org/documentation/amf3#x07_-_xml_legacy_flash.xml.xmldocument_class>}
+#: <http://osflash.org/documentation/amf3#x07_-_xml_legacy_flashxmlxmldocument_class>}
 TYPE_XML = '\x07'
 #: In AMF 3 an ActionScript Date is serialized simply as the number of
 #: milliseconds elapsed since the epoch of midnight, 1st Jan 1970 in the
@@ -159,7 +159,7 @@ class DataOutput(object):
     binary data.
 
     @see: U{IDataOutput on Livedocs (external)
-    <http://livedocs.adobe.com/flex/201/langref/flash/utils/IDataOutput.html>}
+    <http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/utils/IDataOutput.html>}
     """
 
     def __init__(self, encoder):
@@ -244,7 +244,7 @@ class DataOutput(object):
             character set strings include C{shift-jis}, C{cn-gb},
             C{iso-8859-1} and others.
         @see: U{Supported character sets on Livedocs (external)
-            <http://livedocs.adobe.com/flex/201/langref/charset-codes.html>}
+            <http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/charset-codes.html>}
         """
         if type(value) is unicode:
             value = value.encode(charset)
@@ -331,7 +331,7 @@ class DataInput(object):
     which writes binary data.
 
     @see: U{IDataInput on Livedocs (external)
-    <http://livedocs.adobe.com/flex/201/langref/flash/utils/IDataInput.html>}
+    <http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/utils/IDataInput.html>}
     """
 
     def __init__(self, decoder=None):
@@ -502,7 +502,7 @@ class ByteArray(util.BufferedByteStream, DataInput, DataOutput):
      - Optimizing the size of your data by using custom data types.
 
     @see: U{ByteArray on Livedocs (external)
-    <http://livedocs.adobe.com/flex/201/langref/flash/utils/ByteArray.html>}
+    <http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/utils/ByteArray.html>}
     """
 
     _zlib_header = '\x78\x9c'
@@ -836,8 +836,8 @@ class Decoder(codec.Decoder):
 
         @type signed: C{bool}
         @see: U{Parsing integers on OSFlash
-        <http://osflash.org/amf3/parsing_integers>} for the AMF3 integer data
-        format.
+        <http://osflash.org/documentation/amf3/parsing_integers>} for the AMF3
+        integer data format.
         """
         return decode_int(self.stream, signed)
 

--- a/pyamf/flex/__init__.py
+++ b/pyamf/flex/__init__.py
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 """
-Compatibility classes/functions for Flex.
+Compatibility classes/functions for Adobe Flex.
 
 @note: Not available in ActionScript 1.0 and 2.0.
 @see: U{Flex on Wikipedia<http://en.wikipedia.org/wiki/Adobe_Flex>}
@@ -25,7 +25,7 @@ class ArrayCollection(list):
     interfaces in the Flex framework.
 
     @see: U{ArrayCollection on Livedocs <http://
-        livedocs.adobe.com/flex/201/langref/mx/collections/ArrayCollection.html>}
+        help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/mx/collections/ArrayCollection.html>}
     @note: This class does not implement the RemoteObject part of the
         documentation.
     @ivar length: [read-only] The number of items in this collection.
@@ -192,7 +192,7 @@ class ObjectProxy(object):
     dynamic ActionScript Object to be bindable and report change events.
 
     @see: U{ObjectProxy on Livedocs<http://
-        livedocs.adobe.com/flex/201/langref/mx/utils/ObjectProxy.html>}
+        help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/mx/utils/ObjectProxy.html>}
     """
 
     class __amf__:

--- a/pyamf/flex/data.py
+++ b/pyamf/flex/data.py
@@ -37,7 +37,7 @@ class DataMessage(AsyncMessage):
     conflicts.
 
     @see: U{DataMessage on Livedocs<http://
-        livedocs.adobe.com/flex/201/langref/mx/data/messages/DataMessage.html>}
+        help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/mx/data/messages/DataMessage.html>}
     """
 
     def __init__(self):
@@ -58,7 +58,7 @@ class SequencedMessage(AcknowledgeMessage):
     Response to L{DataMessage} requests.
 
     @see: U{SequencedMessage on Livedocs<http://
-        livedocs.adobe.com/flex/201/langref/mx/data/messages/SequencedMessage.html>}
+        help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/mx/data/messages/SequencedMessage.html>}
     """
 
     def __init__(self):
@@ -85,7 +85,7 @@ class PagedMessage(SequencedMessage):
     This messsage provides information about a partial sequence result.
 
     @see: U{PagedMessage on Livedocs<http://
-        livedocs.adobe.com/flex/201/langref/mx/data/messages/PagedMessage.html>}
+        help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/mx/data/messages/PagedMessage.html>}
     """
 
     def __init__(self):
@@ -106,7 +106,7 @@ class DataErrorMessage(ErrorMessage):
     the L{ErrorMessage<pyamf.flex.messaging.ErrorMessage>} information.
 
     @see: U{DataErrorMessage on Livedocs<http://
-        livedocs.adobe.com/flex/201/langref/mx/data/messages/DataErrorMessage.html>}
+        help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/mx/data/messages/DataErrorMessage.html>}
     """
 
     def __init__(self):

--- a/pyamf/flex/messaging.py
+++ b/pyamf/flex/messaging.py
@@ -42,7 +42,7 @@ class AbstractMessage(object):
     that needs to be delivered and processed by the decoder.
 
     @see: U{AbstractMessage on Livedocs<http://
-        livedocs.adobe.com/flex/201/langref/mx/messaging/messages/AbstractMessage.html>}
+        help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/mx/messaging/messages/AbstractMessage.html>}
 
     @ivar body: Specific data that needs to be delivered to the remote
         destination.
@@ -215,7 +215,7 @@ class AsyncMessage(AbstractMessage):
     I am the base class for all asynchronous Flex messages.
 
     @see: U{AsyncMessage on Livedocs<http://
-        livedocs.adobe.com/flex/201/langref/mx/messaging/messages/AsyncMessage.html>}
+        help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/mx/messaging/messages/AsyncMessage.html>}
 
     @ivar correlationId: Correlation id of the message.
     @type correlationId: C{str}
@@ -278,7 +278,7 @@ class AcknowledgeMessage(AsyncMessage):
     acknowledgement.
 
     @see: U{AcknowledgeMessage on Livedocs<http://
-        livedocs.adobe.com/flex/201/langref/mx/messaging/messages/AcknowledgeMessage.html>}
+        help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/mx/messaging/messages/AcknowledgeMessage.html>}
     """
 
     #: Used to indicate that the acknowledgement is for a message that
@@ -315,7 +315,7 @@ class CommandMessage(AsyncMessage):
     messaging, ping, and cluster operations.
 
     @see: U{CommandMessage on Livedocs<http://
-        livedocs.adobe.com/flex/201/langref/mx/messaging/messages/CommandMessage.html>}
+        help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/mx/messaging/messages/CommandMessage.html>}
 
     @ivar operation: The command
     @type operation: C{int}
@@ -410,7 +410,7 @@ class ErrorMessage(AcknowledgeMessage):
     This class is used to report errors within the messaging system.
 
     @see: U{ErrorMessage on Livedocs<http://
-        livedocs.adobe.com/flex/201/langref/mx/messaging/messages/ErrorMessage.html>}
+        help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/mx/messaging/messages/ErrorMessage.html>}
     """
 
     #: If a message may not have been delivered, the faultCode will contain
@@ -455,7 +455,7 @@ class RemotingMessage(AbstractMessage):
     I am used to send RPC requests to a remote endpoint.
 
     @see: U{RemotingMessage on Livedocs<http://
-        livedocs.adobe.com/flex/201/langref/mx/messaging/messages/RemotingMessage.html>}
+        help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/mx/messaging/messages/RemotingMessage.html>}
     """
 
     class __amf__:

--- a/pyamf/remoting/__init__.py
+++ b/pyamf/remoting/__init__.py
@@ -19,7 +19,7 @@ essential for the Adobe Flash Player to understand the response therefore.
 @see: U{Remoting Envelope on OSFlash
     <http://osflash.org/documentation/amf/envelopes/remoting>}
 @see: U{Remoting Headers on OSFlash
-    <http://osflash.org/amf/envelopes/remoting/headers>}
+    <http://osflash.org/documentation/amf/envelopes/remoting/headers>}
 @see: U{Remoting Debug Headers on OSFlash
     <http://osflash.org/documentation/amf/envelopes/remoting/debuginfo>}
 

--- a/pyamf/remoting/client/__init__.py
+++ b/pyamf/remoting/client/__init__.py
@@ -203,7 +203,7 @@ class RemotingService(object):
     @ivar strict: Whether to use strict AMF en/decoding or not.
     @ivar opener: The function used to power the connection to the remote
         server. Defaults to U{urllib2.urlopen<http://
-        docs.python.org/library/urllib2.html#urllib2.urlopen}.
+        docs.python.org/library/urllib2.html#urllib2.urlopen>}.
     """
 
     def __init__(self, url, amf_version=pyamf.AMF0, **kwargs):
@@ -246,7 +246,7 @@ class RemotingService(object):
         Set the proxy for all requests to use.
 
         @see: U{The Python Docs<http://docs.python.org/library/urllib2.html#
-            urllib2.Request.set_proxy}
+            urllib2.Request.set_proxy>}
         """
         self.proxy_args = (host, type)
 


### PR DESCRIPTION
Correct some broken Adobe Livedocs links in the API documentation.

Author: thijs
Fixes: #844
