### PR TITLE
Added logging to buildErrorResponse so that unexpected exceptions will b...

### DIFF
--- a/pyamf/remoting/amf0.py
+++ b/pyamf/remoting/amf0.py
@@ -49,6 +49,9 @@ class RequestProcessor(object):
             cls, e, tb = error
         else:
             cls, e, tb = sys.exc_info()
+        if self.gateway.logger:
+            self.gateway.logger.error("".join(
+                        traceback.format_exception(cls, e, tb)))
 
         return remoting.Response(build_fault(cls, e, tb, self.gateway.debug),
             status=remoting.STATUS_ERROR)


### PR DESCRIPTION
...e logged on the host system if

a log is passed to the gateway
Sorry untested

not quite sure if it should use logging.exception() or logging.error()

here is example output

```python
Traceback (most recent call last):
  File "/base/data/home/apps/s~mediawise-job-queue-beta/0-1-2.357291792738745233/pyamf/remoting/amf0.py", line 110, in __call__
    *args, **kwargs)
  File "/base/data/home/apps/s~mediawise-job-queue-beta/0-1-2.357291792738745233/pyamf/remoting/amf0.py", line 63, in _getBody
    **kwargs)
  File "/base/data/home/apps/s~mediawise-job-queue-beta/0-1-2.357291792738745233/pyamf/remoting/gateway/__init__.py", line 513, in callServiceRequest
    return service_request(*args)
  File "/base/data/home/apps/s~mediawise-job-queue-beta/0-1-2.357291792738745233/pyamf/remoting/gateway/__init__.py", line 233, in __call__
    return self.service(self.method, args)
  File "/base/data/home/apps/s~mediawise-job-queue-beta/0-1-2.357291792738745233/pyamf/remoting/gateway/__init__.py", line 133, in __call__
    return func(*params)
  File "/base/data/home/apps/s~mediawise-job-queue-beta/0-1-2.357291792738745233/model/job_processing_server.py", line 301, in submitJob
    job_id, user, name, job_body)
  File "/base/data/home/apps/s~mediawise-job-queue-beta/0-1-2.357291792738745233/model/job_processing_server.py", line 92, in submitJob
    job = self._submitJob(site_name, job_id, user, name, job_body)
  File "/base/data/home/apps/s~mediawise-job-queue-beta/0-1-2.357291792738745233/model/job_processing_server.py", line 72, in _submitJob
    job.set_job_body(job_body)
  File "/base/data/home/apps/s~mediawise-job-queue-beta/0-1-2.357291792738745233/model/job.py", line 126, in set_job_body
    job_body_container.put()
  File "/base/python27_runtime/python27_lib/versions/1/google/appengine/ext/db/__init__.py", line 1052, in put
    return datastore.Put(self._entity, **kwargs)
  File "/base/python27_runtime/python27_lib/versions/1/google/appengine/api/datastore.py", line 576, in Put
    return PutAsync(entities, **kwargs).get_result()
  File "/base/python27_runtime/python27_lib/versions/1/google/appengine/api/apiproxy_stub_map.py", line 592, in get_result
    return self.__get_result_hook(self)
  File "/base/python27_runtime/python27_lib/versions/1/google/appengine/datastore/datastore_rpc.py", line 1547, in __put_hook
    self.check_rpc_success(rpc)
  File "/base/python27_runtime/python27_lib/versions/1/google/appengine/datastore/datastore_rpc.py", line 1182, in check_rpc_success
    rpc.check_success()
  File "/base/python27_runtime/python27_lib/versions/1/google/appengine/api/apiproxy_stub_map.py", line 558, in check_success
    self.__rpc.CheckSuccess()
  File "/base/python27_runtime/python27_lib/versions/1/google/appengine/api/apiproxy_rpc.py", line 133, in CheckSuccess
    raise self.exception
ArgumentError: An error occurred parsing (locally or remotely) the arguments to datastore_v3.Put().
```