### PR TITLE
Synonyms trouble

### DIFF
--- a/pyamf/alias.py
+++ b/pyamf/alias.py
@@ -476,6 +476,13 @@ class ClassAlias(object):
 
                 attrs[k] = context.getObjectForProxy(v)
 
+        if changed:
+            # apply all filters before synonyms
+            a = {}
+
+            [a.__setitem__(p, attrs[p]) for p in props]
+            attrs = a
+
         if self.synonym_attrs:
             missing = object()
 
@@ -487,14 +494,7 @@ class ClassAlias(object):
 
                 attrs[k] = value
 
-        if not changed:
-            return attrs
-
-        a = {}
-
-        [a.__setitem__(p, attrs[p]) for p in props]
-
-        return a
+        return attrs
 
     def applyAttributes(self, obj, attrs, codec=None):
         """

--- a/pyamf/alias.py
+++ b/pyamf/alias.py
@@ -480,12 +480,12 @@ class ClassAlias(object):
             missing = object()
 
             for k, v in self.synonym_attrs.iteritems():
-                value = attrs.pop(k, missing)
+                value = attrs.pop(v, missing)
 
                 if value is missing:
                     continue
 
-                attrs[v] = value
+                attrs[k] = value
 
         if not changed:
             return attrs

--- a/pyamf/tests/test_alias.py
+++ b/pyamf/tests/test_alias.py
@@ -389,13 +389,13 @@ class GetDecodableAttributesTestCase(unittest.TestCase):
         self.assertFalse(self.alias.shortcut_decode)
 
         attrs = {
-            'foo': 'foo',
+            'bar': 'foo',
             'spam': 'eggs'
         }
 
         ret = self.alias.getDecodableAttributes(self.obj, attrs)
 
-        self.assertEquals(ret, {'bar': 'foo', 'spam': 'eggs'})
+        self.assertEquals(ret, {'foo': 'foo', 'spam': 'eggs'})
 
 
 class ApplyAttributesTestCase(unittest.TestCase):

--- a/pyamf/tests/test_alias.py
+++ b/pyamf/tests/test_alias.py
@@ -397,6 +397,31 @@ class GetDecodableAttributesTestCase(unittest.TestCase):
 
         self.assertEquals(ret, {'foo': 'foo', 'spam': 'eggs'})
 
+    def test_complex_synonym(self):
+        self.alias.synonym_attrs = {'foo_syn': 'bar_syn'}
+        self.alias.compile()
+
+        self.alias.static_properties = ['foo_syn', ]
+        self.alias.exclude_attrs = ['baz', 'gak']
+        self.alias.readonly_attrs = ['spam_rd_1', 'spam_rd_2']
+
+
+        self.assertFalse(self.alias.shortcut_encode)
+        self.assertFalse(self.alias.shortcut_decode)
+
+        attrs = {
+            'bar_syn': 'foo',
+            'spam': 'eggs',
+            'spam_rd_1': 'eggs',
+            'spam_rd_2': 'eggs',
+            'baz': 'remove me',
+            'gak': 'remove me'
+        }
+
+        ret = self.alias.getDecodableAttributes(self.obj, attrs)
+
+        self.assertEquals(ret, {'foo_syn': 'foo', 'spam': 'eggs'})
+
 
 class ApplyAttributesTestCase(unittest.TestCase):
     """


### PR DESCRIPTION
Synonyms feature works during encoding, but it doesn't work properly after decoding.

```python
Python 2.7.1+ (r271:86832, Apr 11 2011, 18:13:53) 
[GCC 4.5.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import pyamf
>>> class X(object):
...     class __amf__:
...         synonym = {'backend_var': 'flashVar'}
...     def __init__(self, value):
...         self.backend_var = value
... 
>>> pyamf.register_class(X, 'X')
<pyamf.alias.ClassAlias alias=u'X' class=<class '__main__.X'> @ 0x1119d90>
>>> pyamf.encode(X('test')).read()
'\n\x0b\x03X\x11flashVar\x06\ttest\x01'
>>> data = pyamf.encode(X('test')).read()
>>> list(pyamf.decode(data))[0]
<__main__.X object at 0x10f2550>
>>> list(pyamf.decode(data))[0].flashVar
u'test'
>>> list(pyamf.decode(data))[0].backend_var
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'X' object has no attribute 'backend_var'
```