### PR TITLE
RemotingService.addHeader method's param must_understand invalid repair

### DIFF
--- a/pyamf/remoting/__init__.py
+++ b/pyamf/remoting/__init__.py
@@ -102,7 +102,7 @@ class HeaderCollection(dict):
         if not idx in self:
             raise KeyError("Unknown header %s" % str(idx))
 
-        if not idx in self.required:
+        if not idx in self.required and value:
             self.required.append(idx)
 
     def __len__(self):


### PR DESCRIPTION
must_unserstand always True when RemotingService addHeader bug repair
