### PR TITLE
Please ship a new version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ import setupinfo
 from setuptools import setup, find_packages
 
 
-version = (0, 6, 1)
+version = (0, 6, 2)
 
 name = "PyAMF"
 description = "AMF support for Python"


### PR DESCRIPTION
Django 1.7 is almost out and the latest stable version of this library is still not compatible with 1.6 as per https://github.com/hydralabs/pyamf/pull/22

Please push a new version to PyPi so we can stop pointing to master. If there is something that needs to be done to make this happen, please let the community know, we'd love to help! If you just don't have the time, add me as a non-owner role on PyPi and I'd be happy to push a new version for you

Also, why are GitHub issues turned off?
