### PR TITLE
Get rid of distribute

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,6 @@
 # Copyright (c) The PyAMF Project.
 # See LICENSE.txt for details.
 
-from distribute_setup import use_setuptools
-
-# 15 seconds is far too long ....
-use_setuptools(download_delay=3)
-
 # import ordering is important
 import setupinfo
 from setuptools import setup, find_packages


### PR DESCRIPTION
Hello, about a year ago distribute was merged back into setuptools, so there is no more need to depend on it instead of setuptools. There is the details: 
https://pythonhosted.org/setuptools/merge.html

For FreeBSD we hold this change as local patch for py-amf port, and it will be great if we can drop it. Here is the similar patch in FreeBSD py-amf port:
https://svnweb.freebsd.org/ports/head/www/py-amf/files/patch-setup.py?revision=335046&view=co
