### PR TITLE
Switch to use defusedxml as the default xml loader.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ python:
   - "2.7"
 sudo: false
 
+cache:
+  directories:
+      - $HOME/.cache/pip
+
 env:
   global:
     - PYTHONPATH=~/gaesdk/google_appengine
@@ -25,6 +29,8 @@ env:
     - SQLALCHEMY_VERSION=">=0.9,<1.0"
     - TWISTED_VERSION=">=14,<15"
     - TWISTED_VERSION=">=15,<16"
+    - LXML_VERSION=">=3.4,<3.5"
+    - LXML_VERSION=">=3.5,<3.6"
     # special, see install_optional_dependencies.sh
     - GAESDK_VERSION=1.9.30
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,10 @@ versions of PyAMF.
 0.8 (Unreleased)
 ----------------
 - Add support for Django>=1.8
+- *Backward incompatible* Wrapped all xml parsing in ``defusedxml`` to protect
+  against any XML entity attacks. See
+  https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Processing for more
+  details. Thanks to Nicolas Grégoire (@Agarri_FR) for the report.
 
 0.7.2 (2015-02-18)
 ------------------

--- a/cpyamf/amf0.pxd
+++ b/cpyamf/amf0.pxd
@@ -1,0 +1,31 @@
+from cpyamf cimport codec, util, amf3
+
+
+cdef class Context(codec.Context):
+    cdef amf3.Context amf3_context
+
+
+cdef class Decoder(codec.Decoder):
+    cdef public bint use_amf3
+    cdef readonly Context context
+    cdef amf3.Decoder amf3_decoder
+
+    cdef object readAMF3(self)
+    cdef object readLongString(self, bint bytes=?)
+    cdef object readMixedArray(self)
+    cdef object readReference(self)
+    cdef object readTypedObject(self)
+    cdef void readObjectAttributes(self, object obj_attrs)
+    cdef object readBytes(self)
+    cdef object readBoolean(self)
+
+
+cdef class Encoder(codec.Encoder):
+    cdef public bint use_amf3
+    cdef readonly Context context
+    cdef amf3.Encoder amf3_encoder
+
+    cdef inline int _writeEndObject(self) except -1
+    cdef int writeAMF3(self, o) except -1
+    cdef int _writeDict(self, dict attrs) except -1
+    cdef inline int writeReference(self, o) except -2

--- a/cpyamf/amf0.pyx
+++ b/cpyamf/amf0.pyx
@@ -45,8 +45,6 @@ cdef object UnknownClassAlias = pyamf.UnknownClassAlias
 
 
 cdef class Context(codec.Context):
-    cdef amf3.Context amf3_context
-
     cpdef int clear(self) except -1:
         codec.Context.clear(self)
 
@@ -60,10 +58,6 @@ cdef class Decoder(codec.Decoder):
     """
     """
 
-    cdef public bint use_amf3
-    cdef readonly Context context
-    cdef amf3.Decoder amf3_decoder
-
     def __cinit__(self):
         self.use_amf3 = 0
 
@@ -72,7 +66,7 @@ cdef class Decoder(codec.Decoder):
         self.context = kwargs.pop('context', None)
 
         if self.context is None:
-            self.context = Context()
+            self.context = Context(**kwargs)
 
         codec.Codec.__init__(self, *args, **kwargs)
 
@@ -244,7 +238,11 @@ cdef class Decoder(codec.Decoder):
 
     cdef object readXML(self):
         cdef object data = self.readLongString()
-        cdef object root = xml.fromstring(data)
+        cdef object root = xml.fromstring(
+            data,
+            forbid_dtd=self.context.forbid_dtd,
+            forbid_entities=self.context.forbid_entities
+        )
 
         self.context.addObject(root)
 
@@ -301,10 +299,6 @@ cdef class Encoder(codec.Encoder):
     The AMF0 Encoder.
     """
 
-    cdef public bint use_amf3
-    cdef readonly Context context
-    cdef amf3.Encoder amf3_encoder
-
     def __cinit__(self):
         self.use_amf3 = 0
 
@@ -314,7 +308,7 @@ cdef class Encoder(codec.Encoder):
         self.context = kwargs.pop('context', None)
 
         if self.context is None:
-            self.context = Context()
+            self.context = Context(**kwargs)
 
         codec.Codec.__init__(self, *args, **kwargs)
 

--- a/cpyamf/amf3.pyx
+++ b/cpyamf/amf3.pyx
@@ -510,7 +510,11 @@ cdef class Decoder(codec.Decoder):
         self.stream.read(&buf, ref)
         s = PyString_FromStringAndSize(buf, ref)
 
-        x = xml.fromstring(s)
+        x = xml.fromstring(
+            s,
+            forbid_dtd=self.context.forbid_dtd,
+            forbid_entities=self.context.forbid_entities
+        )
         self.context.addObject(x)
 
         return x

--- a/cpyamf/codec.pxd
+++ b/cpyamf/codec.pxd
@@ -50,6 +50,8 @@ cdef class Context(object):
     cdef dict unicodes
     cdef dict _strings
     cdef public dict extra
+    cdef public bint forbid_dtd
+    cdef public bint forbid_entities
 
     cpdef int clear(self) except -1
     cpdef object getClassAlias(self, object klass)

--- a/cpyamf/codec.pyx
+++ b/cpyamf/codec.pyx
@@ -229,11 +229,16 @@ cdef class Context(object):
 
     def __cinit__(self):
         self.objects = IndexedCollection()
+        self.forbid_entities = True
+        self.forbid_dtd = True
 
         self.clear()
 
-    def __init__(self):
+    def __init__(self, forbid_dtd=True, forbid_entities=True, **kwargs):
         self.clear()
+
+        self.forbid_entities = forbid_entities
+        self.forbid_dtd = forbid_dtd
 
     cpdef int clear(self) except -1:
         self.objects.clear()
@@ -341,7 +346,8 @@ cdef class Codec(object):
         self.strict = 0
         self.timezone_offset = None
 
-    def __init__(self, stream=None, strict=False, timezone_offset=None):
+    def __init__(self, stream=None, strict=False, timezone_offset=None,
+                 forbid_entities=True, forbid_dtd=True):
         if not isinstance(stream, BufferedByteStream):
             stream = BufferedByteStream(stream)
 
@@ -349,6 +355,9 @@ cdef class Codec(object):
         self.strict = strict
 
         self.timezone_offset = timezone_offset
+
+        self.context.forbid_entities = <bint>forbid_entities
+        self.context.forbid_dtd = <bint>forbid_dtd
 
 
 cdef class Decoder(Codec):

--- a/install_optional_dependencies.sh
+++ b/install_optional_dependencies.sh
@@ -27,6 +27,14 @@ function install_twisted {
   pip install "Twisted${TWISTED_VERSION}"
 }
 
+function install_lxml {
+  if [ -z "${LXML_VERSION}" ]; then
+      return 0
+  fi
+
+  pip install "lxml${LXML_VERSION}"
+}
+
 function install_gae_sdk {
   if [ -z "${GAESDK_VERSION}" ]; then
       return 0
@@ -40,4 +48,5 @@ function install_gae_sdk {
 install_django
 install_sqlalchemy
 install_twisted
+install_lxml
 install_gae_sdk

--- a/pyamf/amf0.py
+++ b/pyamf/amf0.py
@@ -145,8 +145,8 @@ class Decoder(codec.Decoder):
     Decodes an AMF0 stream.
     """
 
-    def buildContext(self):
-        return Context()
+    def buildContext(self, **kwargs):
+        return Context(**kwargs)
 
     def getTypeFunc(self, data):
         # great for coverage, sucks for readability
@@ -380,7 +380,11 @@ class Decoder(codec.Decoder):
         Read XML.
         """
         data = self.readLongString()
-        root = xml.fromstring(data)
+        root = xml.fromstring(
+            data,
+            forbid_dtd=self.context.forbid_dtd,
+            forbid_entities=self.context.forbid_entities,
+        )
 
         self.context.addObject(root)
 
@@ -401,8 +405,8 @@ class Encoder(codec.Encoder):
 
         self.use_amf3 = kwargs.pop('use_amf3', False)
 
-    def buildContext(self):
-        return Context()
+    def buildContext(self, **kwargs):
+        return Context(**kwargs)
 
     def getTypeFunc(self, data):
         if self.use_amf3:

--- a/pyamf/amf3.py
+++ b/pyamf/amf3.py
@@ -607,14 +607,14 @@ class Context(codec.Context):
     @type classes: C{list}
     """
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         self.strings = codec.ByteStringReferenceCollection()
         self.classes = {}
         self.class_ref = {}
 
         self.class_idx = 0
 
-        codec.Context.__init__(self)
+        codec.Context.__init__(self, **kwargs)
 
     def clear(self):
         """
@@ -765,8 +765,8 @@ class Decoder(codec.Decoder):
 
         codec.Decoder.__init__(self, *args, **kwargs)
 
-    def buildContext(self):
-        return Context()
+    def buildContext(self, **kwargs):
+        return Context(**kwargs)
 
     def getTypeFunc(self, data):
         if data == TYPE_UNDEFINED:
@@ -1079,7 +1079,11 @@ class Decoder(codec.Decoder):
 
         xmlstring = self.stream.read(ref >> 1)
 
-        x = xml.fromstring(xmlstring)
+        x = xml.fromstring(
+            xmlstring,
+            forbid_dtd=self.context.forbid_dtd,
+            forbid_entities=self.context.forbid_entities,
+        )
         self.context.addObject(x)
 
         return x
@@ -1136,8 +1140,8 @@ class Encoder(codec.Encoder):
 
         codec.Encoder.__init__(self, *args, **kwargs)
 
-    def buildContext(self):
-        return Context()
+    def buildContext(self, **kwargs):
+        return Context(**kwargs)
 
     def getTypeFunc(self, data):
         """

--- a/pyamf/remoting/__init__.py
+++ b/pyamf/remoting/__init__.py
@@ -584,7 +584,8 @@ def get_fault(data):
     return get_fault_class(level, **e)(**e)
 
 
-def decode(stream, strict=False, logger=None, timezone_offset=None):
+def decode(stream, strict=False, logger=None, timezone_offset=None,
+           **kwargs):
     """
     Decodes the incoming stream as a remoting message.
 
@@ -623,7 +624,8 @@ def decode(stream, strict=False, logger=None, timezone_offset=None):
         pyamf.AMF0,
         stream,
         strict=strict,
-        timezone_offset=timezone_offset
+        timezone_offset=timezone_offset,
+        **kwargs
     )
     context = decoder.context
 
@@ -651,7 +653,7 @@ def decode(stream, strict=False, logger=None, timezone_offset=None):
     return msg
 
 
-def encode(msg, strict=False, logger=None, timezone_offset=None):
+def encode(msg, strict=False, logger=None, timezone_offset=None, **kwargs):
     """
     Encodes and returns the L{msg<Envelope>} as an AMF stream.
 
@@ -677,6 +679,7 @@ def encode(msg, strict=False, logger=None, timezone_offset=None):
         stream,
         strict=strict,
         timezone_offset=timezone_offset,
+        **kwargs
     )
 
     if msg.amfVersion == pyamf.AMF3:

--- a/pyamf/xml.py
+++ b/pyamf/xml.py
@@ -10,11 +10,9 @@ Provides XML support.
 #: list of supported third party packages that support the C{etree}
 #: interface. At least enough for our needs anyway.
 ETREE_MODULES = [
-    'lxml.etree',
-    'xml.etree.cElementTree',
-    'cElementTree',
-    'xml.etree.ElementTree',
-    'elementtree.ElementTree'
+    'defusedxml.lxml',
+    'defusedxml.cElementTree',
+    'defusedxml.ElementTree',
 ]
 
 #: A tuple of class/type objects that are used to represent XML objects.
@@ -165,5 +163,8 @@ def fromstring(*args, **kwargs):
     global ET
 
     _bootstrap()
+
+    kwargs.setdefault('forbid_dtd', True)
+    kwargs.setdefault('forbid_entities', True)
 
     return ET.fromstring(*args, **kwargs)

--- a/setupinfo.py
+++ b/setupinfo.py
@@ -172,7 +172,7 @@ def get_install_requirements():
     Returns a list of dependencies for PyAMF to function correctly on the
     target platform.
     """
-    install_requires = []
+    install_requires = ['defusedxml']
 
     if sys.version_info < (2, 5):
         install_requires.extend(["elementtree>=1.2.6", "uuid>=1.30"])


### PR DESCRIPTION
By default, PyAMF will not support potentially vulnerable XML payloads. See
https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Processing.

Wrap all calls to ``etree.fromstring()`` with ``defusedxml``. All the standard XML processing libs that PyAMF previously supported are still supported.

There may be people who use DTD/Entities as part of their AMF payloads - they will have
to continue to use an old version or make an issue to see how their use case can still be
supported.