### PR TITLE
Use equality testing instead of identity testing when checking for empty modules.

### DIFF
--- a/pyamf/util/__init__.py
+++ b/pyamf/util/__init__.py
@@ -198,7 +198,7 @@ def get_module(mod_name):
     """
     Load and return a module based on C{mod_name}.
     """
-    if mod_name is '':
+    if mod_name == '':
         raise ImportError('Unable to import empty module')
 
     mod = __import__(mod_name)


### PR DESCRIPTION
I noticed a warning about this while updating the Google Cloud AppEngine SDK on an Ubuntu machine.

For more information about the difference between the two checks, see:
https://stackoverflow.com/questions/1504717/why-does-comparing-strings-using-either-or-is-sometimes-produce-a-differe
