### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pyamf/__init__.py
+++ b/pyamf/__init__.py
@@ -917,7 +917,7 @@ def register_package(module=None, package=None, separator='.', ignore=None,
 
 def set_default_etree(etree):
     """
-    Sets the default interface that will called apon to both de/serialise XML
+    Sets the default interface that will called upon to both de/serialise XML
     entities. This means providing both C{tostring} and C{fromstring}
     functions.
 

--- a/pyamf/alias.py
+++ b/pyamf/alias.py
@@ -462,7 +462,7 @@ class ClassAlias(object):
         based on the supplied C{attrs}. This allows for fine grain control
         over what will finally end up on the object or not.
 
-        @param obj: The object that will recieve the attributes.
+        @param obj: The object that will receive the attributes.
         @param attrs: The C{attrs} dictionary that has been decoded.
         @param codec: An optional argument that will contain the decoder
             instance calling this function.

--- a/pyamf/flex/data.py
+++ b/pyamf/flex/data.py
@@ -27,7 +27,7 @@ __all__ = [
 
 class DataMessage(AsyncMessage):
     """
-    I am used to transport an operation that occured on a managed object
+    I am used to transport an operation that occurred on a managed object
     or collection.
 
     This class of message is transmitted between clients subscribed to a
@@ -115,7 +115,7 @@ class DataErrorMessage(ErrorMessage):
 
     def __init__(self):
         ErrorMessage.__init__(self)
-        #: The client oringinated message which caused the conflict.
+        #: The client originated message which caused the conflict.
         self.cause = None
         #: An array of properties that were found to be conflicting
         #: between the client and server objects.

--- a/pyamf/tests/__init__.py
+++ b/pyamf/tests/__init__.py
@@ -22,7 +22,7 @@ if not hasattr(unittest.TestCase, 'assertIdentical'):
     def assertIdentical(self, first, second, msg=None):
         """
         Fail the test if C{first} is not C{second}.  This is an
-        obect-identity-equality test, not an object equality (i.e. C{__eq__})
+        object-identity-equality test, not an object equality (i.e. C{__eq__})
         test.
 
         @param msg: if msg is None, then the failure message will be

--- a/pyamf/tests/test_alias.py
+++ b/pyamf/tests/test_alias.py
@@ -49,7 +49,7 @@ class ClassAliasTestCase(ClassCacheClearingTestCase):
 
     def test_init_deferred(self):
         """
-        Test for initial deferred compliation
+        Test for initial deferred compilation
         """
         x = ClassAlias(Spam, defer=True)
 
@@ -502,7 +502,7 @@ class ApplyAttributesTestCase(unittest.TestCase):
 
 class SimpleCompliationTestCase(unittest.TestCase):
     """
-    Tests for L{ClassAlias} property compliation for no inheritance.
+    Tests for L{ClassAlias} property compilation for no inheritance.
     """
 
     def test_compiled(self):

--- a/pyamf/tests/test_amf3.py
+++ b/pyamf/tests/test_amf3.py
@@ -1073,7 +1073,7 @@ class ObjectEncodingTestCase(ClassCacheClearingTestCase, EncoderMixIn):
     def test_anonymous_class_references(self):
         """
         Test to ensure anonymous class references with static attributes
-        are encoded propertly
+        are encoded properly
         """
         class Foo:
             class __amf__:

--- a/pyamf/tests/test_gateway.py
+++ b/pyamf/tests/test_gateway.py
@@ -380,7 +380,7 @@ class BaseGatewayTestCase(unittest.TestCase):
         self.assertEqual(response.body, 'spam')
 
     def test_unknown_service(self):
-        # Test a non existant service call
+        # Test a non existent service call
         gw = gateway.BaseGateway({'test': TestService})
         envelope = remoting.Envelope()
 
@@ -398,11 +398,11 @@ class BaseGatewayTestCase(unittest.TestCase):
         self.assertEqual(response.body.details, None)
 
     def test_debug_traceback(self):
-        # Test a non existant service call
+        # Test a non existent service call
         gw = gateway.BaseGateway({'test': TestService}, debug=True)
         envelope = remoting.Envelope()
 
-        # Test a non existant service call
+        # Test a non existent service call
         request = remoting.Request('nope', envelope=envelope)
         processor = gw.getProcessor(request)
         response = processor(request)


### PR DESCRIPTION
There are small typos in:
- pyamf/__init__.py
- pyamf/alias.py
- pyamf/flex/data.py
- pyamf/tests/__init__.py
- pyamf/tests/test_alias.py
- pyamf/tests/test_amf3.py
- pyamf/tests/test_gateway.py

Fixes:
- Should read `existent` rather than `existant`.
- Should read `compilation` rather than `compliation`.
- Should read `upon` rather than `apon`.
- Should read `receive` rather than `recieve`.
- Should read `properly` rather than `propertly`.
- Should read `originated` rather than `oringinated`.
- Should read `occurred` rather than `occured`.
- Should read `object` rather than `obect`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md